### PR TITLE
Fixed dependency of python

### DIFF
--- a/package.xml
+++ b/package.xml
@@ -15,7 +15,7 @@
 
   <depend>eigen_catkin</depend>
   <depend>glog_catkin</depend>
-  <depend>PythonLibs</depend>
+  <depend>python</depend>
 
-<test_depend>gtest</test_depend>
+  <test_depend>gtest</test_depend>
 </package>


### PR DESCRIPTION
`PythonLibs` is not a dependency rosdep knows about. The proper thing would be to depend on `python` which rosdep maps to the ubuntu package `python-dev`: https://github.com/ros/rosdistro/blob/master/rosdep/python.yaml#L211